### PR TITLE
Move and rename Windy biome group

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,6 +13,10 @@ Biomes:
   - FLOWER_FOREST
   - OLD_GROWTH_BIRCH_FOREST
   - WINDSWEPT_FOREST
+- Name: Windswept
+  Biomes:
+  - WINDSWEPT_HILLS
+  - WINDSWEPT_GRAVELLY_HILLS
 - Name: Mountains
   Biomes:
   - SNOWY_SLOPES
@@ -100,7 +104,3 @@ Biomes:
   - CRIMSON_FOREST
   - WARPED_FOREST
   - BASALT_DELTAS
-- Name: Windy
-  Biomes:
-  - WINDSWEPT_HILLS
-  - WINDSWEPT_GRAVELLY_HILLS


### PR DESCRIPTION
Rename group to Windswept, place group between Forest and Mountains

Renamed to from Windy to Windswept to stick to the Vanilla biome naming scheme.
Nether used to be the last biome in the list, which made sense to me as it is a separate dimension, this moves the Windswept group to a spot where I think it makes more sense.